### PR TITLE
Add note about also installing python-misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ ntpdate -b -s -u pool.ntp.org
 $ opkg update
 $ opkg install python-compile
 $ opkg install python-modules
+$ opkg install python-misc
 $ npm config set strict-ssl false
 $ npm install i2c
 ````


### PR DESCRIPTION
Without python-misc, building fails on the BeagleBone Black.
