### PR TITLE
Emit empty string instead of 1 to trigger repl

### DIFF
--- a/lib/i2c.coffee
+++ b/lib/i2c.coffee
@@ -15,7 +15,7 @@ class i2c extends EventEmitter
       require('repl').start(
         prompt: "i2c > "
       ).context.wire = @
-      process.stdin.emit 'data', 1 # trigger repl
+      process.stdin.emit 'data', '' # trigger repl
 
     process.on 'exit', => @close()
 


### PR DESCRIPTION
Closes #12

Instead of emitting a 1, emit an empty string.

Tested on Raspberry Pi, Node 0.10.20.
