### PR TITLE
Add i2c-dev to modules to load with modprobe

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Load kernel module
 
 ````bash
 $ sudo modprobe i2c-bcm2708
+$ sudo modprobe i2c-dev
 ````
 
 Make device writable 


### PR DESCRIPTION
Need to `modprobe i2c-dev` to work without restarting
