### PR TITLE
Fixed res type for read byte to handle 0xFF

### DIFF
--- a/src/i2c.cc
+++ b/src/i2c.cc
@@ -100,7 +100,7 @@ Handle<Value> ReadByte(const Arguments& args) {
   Local<Value> data; 
   Local<Value> err = Local<Value>::New(Null());
 
-  int8_t res = i2c_smbus_read_byte(fd);
+  int32_t res = i2c_smbus_read_byte(fd);
 
   if (res == -1) { 
     err = Exception::Error(String::New("Cannot read device"));


### PR DESCRIPTION
`i2c_smbus_read_byte` returns a signed **32** bit interger, not 8 bit.

Reading the byte `0xFF` currently causes a Segmentation Fault, this fixes that.
