### PR TITLE
variable name is wrong

### DIFF
--- a/lib/i2c.coffee
+++ b/lib/i2c.coffee
@@ -24,7 +24,7 @@ class i2c extends EventEmitter
       @history.push data
 
     @on 'error', (err) ->
-      console.log "Error: #{error}"
+      console.log "Error: #{err}"
 
     @open @options.device, (err) =>
       unless err then @setAddress @address


### PR DESCRIPTION
the error variable name was wrong, which leads to an exception.