### PR TITLE
Update i2c for Node js 'Nan' module (Resolve bugs #69 and #75) 

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,10 @@
   "targets": [
     {
       "target_name": "i2c",
-      "sources": [ "src/i2c.cc" ]
+      "sources": [ "src/i2c.cc" ],
+      "include_dirs" : [ 
+          "<!(node -e \"require('nan')\")" 
+      ]
     }
-  ]
+  ]  
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i2c",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Native bindings for i2c-dev. Plays well with Raspberry Pi and BeagleBone.",
   "main": "main.js",
   "author": "Kelly Korevec",
@@ -13,7 +13,8 @@
     "bindings": "1.2.1",
     "underscore": "1.8.2",
     "coffee-script": "1.9.1",
-    "repl":"0.1.3"
+    "repl":"0.1.3",
+    "nan": "~2.3.5"
   },
   "engine": "node >= 0.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "http://github.com/korevec/node-i2c.git"
   },
-  "license": "BSD",
+  "license": "BSD-3-Clause-Attribution",
   "dependencies": {
     "bindings": "1.2.1",
     "underscore": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i2c",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Native bindings for i2c-dev. Plays well with Raspberry Pi and BeagleBone.",
   "main": "main.js",
   "author": "Kelly Korevec",

--- a/src/i2c.cc
+++ b/src/i2c.cc
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
+#include <nan.h>
 #include "i2c-dev.h"
 
 using namespace v8;
@@ -159,7 +160,10 @@ void ReadBlock(const FunctionCallbackInfo<Value>& args) {
   int32_t len = args[1]->Int32Value();
   uint8_t data[len]; 
   Local<Value> err = Local<Value>::New(isolate, Null(isolate));
-  Local<Object> buffer = node::Buffer::New(len);
+  // Local<Object> buffer = node::Buffer::New(len);
+  //new version for all node versions
+  Local<Object> buffer = Nan::NewBuffer(len).ToLocalChecked();  //todo some error checking here as the devs intended
+
 
   while (fd > 0) {
     if (i2c_smbus_read_i2c_block_data(fd, cmd, len, data) != len) {

--- a/src/i2c.cc
+++ b/src/i2c.cc
@@ -1,6 +1,6 @@
 #include <node.h>
 #include <node_buffer.h>
-#include <v8.h>
+#include <nan.h>
 #include <fcntl.h>
 #include <stdint.h>
 #include <errno.h>
@@ -8,8 +8,8 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
-#include <nan.h>
 #include "i2c-dev.h"
+
 
 using namespace v8;
 int fd;
@@ -17,32 +17,35 @@ int8_t addr;
 
 void setAddress(int8_t addr) {
   Isolate* isolate = Isolate::GetCurrent();
+  Nan::HandleScope scope;
 
   int result = ioctl(fd, I2C_SLAVE_FORCE, addr);
   if (result == -1) {
     isolate->ThrowException(
-      Exception::TypeError(String::NewFromUtf8(isolate, "Failed to set address"))
+      Exception::TypeError(Nan::New("Failed to set address").ToLocalChecked())
     );
     return;
   }
 }
 
-void SetAddress(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void SetAddress(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
-  addr = args[0]->Int32Value();
+  if (!info[0]->IsNumber()) {
+    Nan::ThrowTypeError("addr must be an int");
+    return;
+  }
+  addr = info[0]->Int32Value();
   setAddress(addr);
 }
 
-void Scan(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void Scan(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
   int i, res;
-  Local<Function> callback = Local<Function>::Cast(args[0]);
-  Local<Array> results = Array::New(isolate, 128);
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  Local<Function> callback = Local<Function>::Cast(info[0]);
+  Local<Array> results = Nan::New<Array>(128);
+  Local<Value> err = Nan::New<Value>(Nan::Null());
 
   for (i = 0; i < 128; i++) {
     setAddress(i);
@@ -54,244 +57,239 @@ void Scan(const FunctionCallbackInfo<Value>& args) {
     if (res >= 0) {
       res = i;
     }
-    results->Set(i, Integer::New(isolate, res));
+    results->Set(i, Nan::New<Integer>(res));
   }
 
   setAddress(addr);
 
   const unsigned argc = 2;
   Local<Value> argv[argc] = { err, results };
-  callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
 
-  args.GetReturnValue().Set(results);
+  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
+
+  info.GetReturnValue().Set(results);
 }
 
-void Close(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void Close(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
   if (fd > 0) {
     close(fd);
   }
 }
 
-void Open(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void Open(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
-  String::Utf8Value device(args[0]);
-
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  String::Utf8Value device(info[0]);
+  Local<Value> err = Nan::New<Value>(Nan::Null());
 
   fd = open(*device, O_RDWR);
   if (fd == -1) {
-    err = Exception::Error(String::NewFromUtf8(isolate, "Failed to open I2C device"));
+    err = Nan::Error(Nan::New("Failed to open I2C device").ToLocalChecked());
   }
 
-  if (args[1]->IsFunction()) {
+  if (info[1]->IsFunction()) {
     const unsigned argc = 1;
-    Local<Function> callback = Local<Function>::Cast(args[1]);
+    Local<Function> callback = Local<Function>::Cast(info[1]);
     Local<Value> argv[argc] = { err };
-
-    callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
   }
 }
 
-void Read(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void Read(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
-  int len = args[0]->Int32Value();
+  int len = info[0]->Int32Value();
 
-  Local<Array> data = Array::New(isolate);
+  Local<Array> data = Nan::New<Array>();
 
   char* buf = new char[len];
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  Local<Value> err = Nan::New<Value>(Nan::Null());
 
   if (read(fd, buf, len) != len) {
-    err = Exception::Error(String::NewFromUtf8(isolate, "Cannot read from device"));
+    err = Nan::Error(Nan::New("Cannot read from device").ToLocalChecked());
   } else {
     for (int i = 0; i < len; ++i) {
-      data->Set(i, Integer::New(isolate, buf[i]));
+      data->Set(i, Nan::New<Integer>(buf[i]));
     }
   }
   delete[] buf;
 
-  if (args[1]->IsFunction()) {
+  if (info[1]->IsFunction()) {
     const unsigned argc = 2;
-    Local<Function> callback = Local<Function>::Cast(args[1]);
+    Local<Function> callback = Local<Function>::Cast(info[1]);
     Local<Value> argv[argc] = { err, data };
-
-    callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
   }
 }
 
-void ReadByte(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void ReadByte(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
   
   Local<Value> data; 
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  Local<Value> err = Nan::New<Value>(Nan::Null());
 
   int32_t res = i2c_smbus_read_byte(fd);
 
   if (res == -1) { 
-    err = Exception::Error(String::NewFromUtf8(isolate, "Cannot read device"));
+    err = Nan::Error(Nan::New("Cannot read device").ToLocalChecked());
   } else {
-    data = Integer::New(isolate, res);
+    data = Nan::New<Integer>(res);
   }
 
-  if (args[0]->IsFunction()) {
+  if (info[0]->IsFunction()) {
     const unsigned argc = 2;
-    Local<Function> callback = Local<Function>::Cast(args[0]);
+    Local<Function> callback = Local<Function>::Cast(info[0]);
     Local<Value> argv[argc] = { err, data };
-
-    callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
   }
 
-  args.GetReturnValue().Set(data);
+  info.GetReturnValue().Set(data);
 }
 
-void ReadBlock(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void ReadBlock(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
-  int8_t cmd = args[0]->Int32Value();
-  int32_t len = args[1]->Int32Value();
+  int8_t cmd = info[0]->Int32Value();
+  int32_t len = info[1]->Int32Value();
   uint8_t data[len]; 
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  Local<Value> err = Nan::New<Value>(Nan::Null());
   // Local<Object> buffer = node::Buffer::New(len);
-  //new version for all node versions
-  Local<Object> buffer = Nan::NewBuffer(len).ToLocalChecked();  //todo some error checking here as the devs intended
+  //new version for Nan
+  Local<Object> buffer = Nan::NewBuffer(len).ToLocalChecked();  //todo  - some error checking here as the devs intended?
 
 
   while (fd > 0) {
     if (i2c_smbus_read_i2c_block_data(fd, cmd, len, data) != len) {
-      err = Exception::Error(String::NewFromUtf8(isolate, "Error reading length of bytes"));
+      err = Nan::Error(Nan::New("Error reading length of bytes").ToLocalChecked());
     }
 
     memcpy(node::Buffer::Data(buffer), data, len);
 
-    if (args[3]->IsFunction()) {
+    if (info[3]->IsFunction()) {
       const unsigned argc = 2;
-      Local<Function> callback = Local<Function>::Cast(args[3]);
+      Local<Function> callback = Local<Function>::Cast(info[3]);
       Local<Value> argv[argc] = { err, buffer };
-      callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+      Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
     }
  
-    if (args[2]->IsNumber()) {
-      int32_t delay = args[2]->Int32Value();
+    if (info[2]->IsNumber()) {
+      int32_t delay = info[2]->Int32Value();
       usleep(delay * 1000);
     } else {
       break;
     }
   }
 
-  args.GetReturnValue().Set(buffer);
+  info.GetReturnValue().Set(buffer);
 }
 
-void Write(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void Write(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
-  Local<Value> buffer = args[0];
+  Local<Value> buffer = info[0];
 
   int   len = node::Buffer::Length(buffer->ToObject());
   char* data = node::Buffer::Data(buffer->ToObject());
 
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  Local<Value> err = Nan::New<Value>(Nan::Null());
 
   if (write(fd, (unsigned char*) data, len) != len) {
-    err = Exception::Error(String::NewFromUtf8(isolate, "Cannot write to device"));
+    err = Nan::Error(Nan::New("Cannot write to device").ToLocalChecked());
   }
 
-  if (args[1]->IsFunction()) {
+  if (info[1]->IsFunction()) {
     const unsigned argc = 1;
-    Local<Function> callback = Local<Function>::Cast(args[1]);
+    Local<Function> callback = Local<Function>::Cast(info[1]);
     Local<Value> argv[argc] = { err };
-
-    callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
   }
 }
 
-void WriteByte(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void WriteByte(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
-  int8_t byte = args[0]->Int32Value();
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  int8_t byte = info[0]->Int32Value();
+  Local<Value> err = Nan::New<Value>(Nan::Null());
 
   if (i2c_smbus_write_byte(fd, byte) == -1) {
-    err = Exception::Error(String::NewFromUtf8(isolate, "Cannot write to device"));
+    err = Nan::Error(Nan::New("Cannot write to device").ToLocalChecked());
   }
 
-  if (args[1]->IsFunction()) {
+  if (info[1]->IsFunction()) {
     const unsigned argc = 1;
-    Local<Function> callback = Local<Function>::Cast(args[1]);
+    Local<Function> callback = Local<Function>::Cast(info[1]);
     Local<Value> argv[argc] = { err };
-
-    callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
   }
 }
 
-void WriteBlock(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void WriteBlock(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
 
-  Local<Value> buffer = args[1];
-
-  int8_t cmd = args[0]->Int32Value();
+  Local<Value> buffer = info[1];
+  int8_t cmd = info[0]->Int32Value();
   int   len = node::Buffer::Length(buffer->ToObject());
   char* data = node::Buffer::Data(buffer->ToObject());
 
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  Local<Value> err = Nan::New<Value>(Nan::Null());
 
   if (i2c_smbus_write_i2c_block_data(fd, cmd, len, (unsigned char*) data) == -1) {
-    err = Exception::Error(String::NewFromUtf8(isolate, "Cannot write to device"));
+    err = Nan::Error(Nan::New("Cannot write to device").ToLocalChecked());
   }
 
-  if (args[2]->IsFunction()) {
+  if (info[2]->IsFunction()) {
     const unsigned argc = 1;
-    Local<Function> callback = Local<Function>::Cast(args[2]);
+    Local<Function> callback = Local<Function>::Cast(info[2]);
     Local<Value> argv[argc] = { err };
-
-    callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
   }
 }
 
-void WriteWord(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = Isolate::GetCurrent();
-  HandleScope scope(isolate);
+void WriteWord(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Nan::HandleScope scope;
   
-  int8_t cmd = args[0]->Int32Value();
-  int16_t word = args[1]->Int32Value();
+  int8_t cmd = info[0]->Int32Value();
+  int16_t word = info[1]->Int32Value();
 
-  Local<Value> err = Local<Value>::New(isolate, Null(isolate));
+  Local<Value> err = Nan::New<Value>(Nan::Null());
   
   if (i2c_smbus_write_word_data(fd, cmd, word) == -1) {
-    err = Exception::Error(String::NewFromUtf8(isolate, "Cannot write to device"));
+    err = Nan::Error(Nan::New("Cannot write to device").ToLocalChecked());
   }
 
-  if (args[2]->IsFunction()) {
+  if (info[2]->IsFunction()) {
     const unsigned argc = 1;
-    Local<Function> callback = Local<Function>::Cast(args[2]);
+    Local<Function> callback = Local<Function>::Cast(info[2]);
     Local<Value> argv[argc] = { err };
-
-    callback->Call(isolate->GetCurrentContext()->Global(), argc, argv);
+    Nan::MakeCallback(Nan::GetCurrentContext()->Global(), callback, argc, argv);
   }
 }
 
 void Init(Handle<Object> exports) {
-  NODE_SET_METHOD(exports, "setAddress", SetAddress);
-  NODE_SET_METHOD(exports, "scan", Scan);
-  NODE_SET_METHOD(exports, "open", Open);
-  NODE_SET_METHOD(exports, "close", Close);
-  NODE_SET_METHOD(exports, "write", Write);
-  NODE_SET_METHOD(exports, "writeByte", WriteByte);
-  NODE_SET_METHOD(exports, "writeBlock", WriteBlock);
-  NODE_SET_METHOD(exports, "read", Read);
-  NODE_SET_METHOD(exports, "readByte", ReadByte);
-  NODE_SET_METHOD(exports, "readBlock", ReadBlock);
+
+  exports->Set(Nan::New("setAddress").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(SetAddress)->GetFunction());
+  exports->Set(Nan::New("scan").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Scan)->GetFunction());
+  exports->Set(Nan::New("open").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Open)->GetFunction());
+  exports->Set(Nan::New("close").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Close)->GetFunction());
+  exports->Set(Nan::New("write").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Write)->GetFunction());
+  exports->Set(Nan::New("writeByte").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(WriteByte)->GetFunction());
+  exports->Set(Nan::New("writeBlock").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(WriteBlock)->GetFunction());
+  exports->Set(Nan::New("read").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(Read)->GetFunction());
+  exports->Set(Nan::New("readByte").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(ReadByte)->GetFunction());
+  exports->Set(Nan::New("readBlock").ToLocalChecked(),
+               Nan::New<v8::FunctionTemplate>(ReadBlock)->GetFunction());
+
 }
 
 NODE_MODULE(i2c, Init)


### PR DESCRIPTION
The following updates the i2c node module to use Nan wrappers to v8 in order to allow the module to be built on Node.js versions > 4.0.0 (and perhaps also < 0.12?) and to resolve bugs #69 and #75

I've rewritten the **i2c.cc** file to use the [Nan ](https://github.com/nodejs/nan) versions of objects and methods where possible. It represents a fairly extensive rewrite of that file. But I've tried to leave the syntax and structure alone. (This was possible because the Nan wrappers look _a lot_ like their v8 counterparts.)

Note - This code has been tested on Node.js versions 4.4.5 and 6.2.1 but  _only_ on **armhf** (Raspberry Pi 2, oDroid XU3/C0) so far.

Also - fixed the license string in Package.json to be valid and match the 3 clause BSD license in the source package. 

_'Nother Note- As pointed out by @Maus34 Nan relies on **c++11** so you'll need g++ 4.8 or greater._